### PR TITLE
Bump deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 LLVM_jll = "86de99a1-58d6-5da7-8064-bd56ce2e322c"
 
 [compat]
-GPUCompiler = "0.7, 0.8, 0.9"
-LLVM = "1.3, 2, 3"
-LLVM_jll = "9, 11"
+GPUCompiler = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
+LLVM = "1.3, 2, 3, 4"
+LLVM_jll = "9, 11, 12, 13"
 julia = "1.5"


### PR DESCRIPTION
I've only tested that MCAnalyzer passes its tests, with the   latest version of each package bumped

close https://github.com/JuliaPerf/MCAnalyzer.jl/issues/23